### PR TITLE
Add v2 option for pull_saiserver_syncd_rpc_dockers shell

### DIFF
--- a/sonic-scripts/DUTScript/Utils.sh
+++ b/sonic-scripts/DUTScript/Utils.sh
@@ -46,3 +46,17 @@ get_asic() {
 get_os_version() {
     OS_VERSION=`sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version`
 }
+
+check_sai_versions() {
+    # Print helpFunction in case parameters are empty
+    if [ -z "$SAI_VERSION" ]; then
+        echo "version set to default v1.";
+        SAI_VERSION=
+    fi
+
+    #when v1 set the version to null
+    if [[ x"$SAI_VERSION" != x"v2" && x"$SAI_VERSION" != x"" ]]; then
+        echo ""
+        echo "Error: Version perameters is not right, it only can be [v2].";   
+    fi
+}

--- a/sonic-scripts/DUTScript/pull_saiserver_syncd_rpc_dockers.sh
+++ b/sonic-scripts/DUTScript/pull_saiserver_syncd_rpc_dockers.sh
@@ -3,8 +3,21 @@
 get_asic
 get_os_version
 
+while getopts ":v:" args; do
+    case $args in
+        v)
+            SAI_VERSION=${OPTARG} 
+            ;;
+        *)
+            echo -e "\t-v [v1|v2]: saiserver version, support v1 and v2"
+        ;;
+    esac
+done
+
+check_sai_versions
+
 SONIC_REG=acs-repo.corp.microsoft.com:5001
-docker pull ${SONIC_REG}/docker-saiserver-${ASIC}:${OS_VERSION}
-docker tag  ${SONIC_REG}/docker-saiserver-${ASIC}:${OS_VERSION} docker-saiserver-${ASIC}
+docker pull ${SONIC_REG}/docker-saiserver${SAI_VERSION}-${ASIC}:${OS_VERSION}
+docker tag  ${SONIC_REG}/docker-saiserver${SAI_VERSION}-${ASIC}:${OS_VERSION} docker-saiserver${SAI_VERSION}-${ASIC}
 docker pull ${SONIC_REG}/docker-syncd-${ASIC}-rpc:${OS_VERSION}
 docker tag ${SONIC_REG}/docker-syncd-${ASIC}-rpc:${OS_VERSION} docker-syncd-${ASIC}-rpc


### PR DESCRIPTION
1. Add -v parameter for pull_saiserver_syncd_rpc_dockers.sh
2. Usage:  pull_saiserver_syncd_rpc_dockers.sh -v v2 , [-v ,v2] is optional