### PR TITLE
Add sample data for prepare_saiserver_service.sh

### DIFF
--- a/sonic-scripts/DUTScript/brcm-saiserver-files/usr/bin/saiserver.sh
+++ b/sonic-scripts/DUTScript/brcm-saiserver-files/usr/bin/saiserver.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+
+#/usr/bin/saiserver.sh
+# single instance containers are still supported (even though it might not look like it)
+# if no instance number is passed to this script, $DEV will simply be unset, resulting in docker
+# commands being sent to the base container name. E.g. `docker start database$DEV` simply starts
+# the container `database` if no instance number is passed since `$DEV` is not defined
+
+function updateSyslogConf()
+{
+    # On multiNPU platforms, change the syslog target ip to docker0 ip to allow logs from containers
+    # running on the namespace to reach the rsyslog service running on the host
+    # Also update the container name  
+    if [[ ($NUM_ASIC -gt 1) ]]; then
+        TARGET_IP=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
+        CONTAINER_NAME="$DOCKERNAME"
+        TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
+
+        sonic-cfggen -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
+        docker cp $TMP_FILE ${DOCKERNAME}:/etc/rsyslog.conf
+        rm -rf $TMP_FILE
+    fi
+}
+
+function getMountPoint()
+{
+    echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.abspath(mnts[0]['Source'])" 2>/dev/null
+}
+
+function getBootType()
+{
+    # same code snippet in files/scripts/saiserver.sh
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
+        TYPE='warm'
+        ;;
+    *SONIC_BOOT_TYPE=fastfast*)
+        TYPE='fastfast'
+        ;;
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
+        TYPE='fast'
+        ;;
+    *)
+        TYPE='cold'
+    esac
+    echo "${TYPE}"
+}
+
+function preStartAction()
+{
+    : # nothing
+    updateSyslogConf
+}
+
+function postStartAction()
+{
+    : # nothing
+}
+
+start() {
+    # Obtain boot type from kernel arguments
+    BOOT_TYPE=`getBootType`
+
+    # Obtain our platform as we will mount directories with these names in each docker
+    PLATFORM=${PLATFORM:-`$SONIC_CFGGEN -H -v DEVICE_METADATA.localhost.platform`}
+
+
+    # Parse the device specific asic conf file, if it exists
+    ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
+    if [ -f "$ASIC_CONF" ]; then
+        source $ASIC_CONF
+    fi
+    # Obtain our HWSKU as we will mount directories with these names in each docker
+    HWSKU=${HWSKU:-`$SONIC_CFGGEN -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`}
+    MOUNTPATH="/usr/share/sonic/device/$PLATFORM/$HWSKU"
+    if [ "$DEV" ]; then
+        MOUNTPATH="$MOUNTPATH/$DEV"
+    fi
+    DOCKERCHECK=`docker inspect --type container ${DOCKERNAME} 2>/dev/null`
+    if [ "$?" -eq "0" ]; then
+        DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`
+        if [ x"$DOCKERMOUNT" == x"$MOUNTPATH" ]; then
+            preStartAction
+            echo "Starting existing ${DOCKERNAME} container with HWSKU $HWSKU"
+            /usr/local/bin/container start ${DOCKERNAME}
+            postStartAction
+            exit $?
+        fi
+
+        # docker created with a different HWSKU, remove and recreate
+        echo "Removing obsolete ${DOCKERNAME} container with HWSKU $DOCKERMOUNT"
+        docker rm -f ${DOCKERNAME}
+    fi
+    echo "Creating new ${DOCKERNAME} container with HWSKU $HWSKU"
+
+    # In Multi ASIC platforms the global database config file database_global.json will exist.
+    # Parse the file and get the include path for the database_config.json files used in
+    # various namesapces. The database_config paths are relative to the DIR of SONIC_DB_GLOBAL_JSON.
+    SONIC_DB_GLOBAL_JSON="/var/run/redis/sonic-db/database_global.json"
+    if [ -f "$SONIC_DB_GLOBAL_JSON" ]; then
+        # TODO Create a separate python script with the below logic and invoke it here.
+        redis_dir_list=`/usr/bin/python -c "import sys; import os; import json; f=open(sys.argv[1]); \
+                        global_db_dir = os.path.dirname(sys.argv[1]); data=json.load(f); \
+                        print(\" \".join([os.path.normpath(global_db_dir+'/'+elem['include']).partition('sonic-db')[0]\
+                        for elem in data['INCLUDES'] if 'namespace' in elem])); f.close()" $SONIC_DB_GLOBAL_JSON`
+    fi
+
+    if [ -z "$DEV" ]; then
+        NET="host"
+
+        # For Multi-ASIC platform we have to mount the redis paths for database instances running in different
+        # namespaces, into the single instance dockers like snmp, pmon on linux host. These global dockers
+        # will need to get/set tables from databases in different namespaces.
+        # /var/run/redis0 ---> mounted as --> /var/run/redis0
+        # /var/run/redis1 ---> mounted as --> /var/run/redis1 .. etc
+        # The below logic extracts the base DIR's where database_config.json's for various namespaces exist.
+        # redis_dir_list is a string of form "/var/run/redis0/ /var/run/redis1/ /var/run/redis2/"
+        if [ -n "$redis_dir_list" ]; then
+            for redis_dir in $redis_dir_list
+            do
+                REDIS_MNT=$REDIS_MNT" -v $redis_dir:$redis_dir:rw "
+            done
+        fi
+    else
+        # This part of code is applicable for Multi-ASIC platforms. Here we mount the namespace specific
+        # redis directory into the docker running in that namespace. Below eg: is for namespace "asic1"
+        # /var/run/redis1 ---> mounted as --> /var/run/redis1
+        # redis_dir_list is a string of form "/var/run/redis0/ /var/run/redis1/ /var/run/redis2/"
+        if [ -n "$redis_dir_list" ]; then
+            id=`expr $DEV + 1`
+            redis_dir=`echo $redis_dir_list | cut -d " " -f $id`
+            REDIS_MNT=" -v $redis_dir:$redis_dir:rw "
+        fi
+        NET="container:database$DEV"
+        DB_OPT=""
+    fi
+    docker create --privileged -t -v /host/machine.conf:/etc/machine.conf -v /etc/sonic:/etc/sonic:ro -v /host/warmboot:/var/warmboot  \
+        --net=$NET \
+        -e RUNTIME_OWNER=local \
+        --uts=host \
+        --log-opt max-size=2M --log-opt max-file=5 \
+        -v /var/run/docker-saiserverv2$DEV:/var/run/sswsaiserver \
+        -v /var/run/redis$DEV:/var/run/redis:rw \
+        -v /var/run/redis-chassis:/var/run/redis-chassis:ro \
+        -v /usr/share/sonic/device/$PLATFORM/$HWSKU/$DEV:/usr/share/sonic/hwsku:ro \
+        $REDIS_MNT \
+        -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/platform:ro \
+        --tmpfs /tmp \
+        --tmpfs /var/tmp \
+        --env "NAMESPACE_ID"="$DEV" \
+        --env "NAMESPACE_PREFIX"="$NAMESPACE_PREFIX" \
+        --env "NAMESPACE_COUNT"=$NUM_ASIC \
+        --name=$DOCKERNAME docker-saiserverv2-brcm:latest || {
+            echo "Failed to docker run" >&1
+            exit 4
+    }
+
+    preStartAction
+    /usr/local/bin/container start ${DOCKERNAME}
+    postStartAction
+}
+
+wait() {
+    /usr/local/bin/container wait $DOCKERNAME
+}
+
+stop() {
+    /usr/local/bin/container stop $DOCKERNAME
+}
+
+DOCKERNAME=saiserver
+OP=$1
+DEV=$2 # namespace/device number to operate on
+NAMESPACE_PREFIX="asic"
+DOCKERNAME=$DOCKERNAME$DEV
+if [ "$DEV" ]; then
+    NET_NS="$NAMESPACE_PREFIX$DEV" #name of the network namespace
+
+    SONIC_CFGGEN="sonic-cfggen -n $NET_NS"
+    SONIC_DB_CLI="sonic-db-cli -n $NET_NS"
+ else
+    NET_NS=""
+    SONIC_CFGGEN="sonic-cfggen"
+    SONIC_DB_CLI="sonic-db-cli"
+fi
+
+# read SONiC immutable variables
+[ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
+
+case "$1" in
+    start|wait|stop)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {start namespace(optional)|wait namespace(optional)|stop namespace(optional)}"
+        exit 1
+        ;;
+esac

--- a/sonic-scripts/DUTScript/brcm-saiserver-files/usr/bin/syncd.sh
+++ b/sonic-scripts/DUTScript/brcm-saiserver-files/usr/bin/syncd.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+
+#/usr/bin/syncd.sh
+# single instance containers are still supported (even though it might not look like it)
+# if no instance number is passed to this script, $DEV will simply be unset, resulting in docker
+# commands being sent to the base container name. E.g. `docker start database$DEV` simply starts
+# the container `database` if no instance number is passed since `$DEV` is not defined
+
+function updateSyslogConf()
+{
+    # On multiNPU platforms, change the syslog target ip to docker0 ip to allow logs from containers
+    # running on the namespace to reach the rsyslog service running on the host
+    # Also update the container name  
+    if [[ ($NUM_ASIC -gt 1) ]]; then
+        TARGET_IP=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
+        CONTAINER_NAME="$DOCKERNAME"
+        TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
+
+        sonic-cfggen -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
+        docker cp $TMP_FILE ${DOCKERNAME}:/etc/rsyslog.conf
+        rm -rf $TMP_FILE
+    fi
+}
+
+function getMountPoint()
+{
+    echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.abspath(mnts[0]['Source'])" 2>/dev/null
+}
+
+function getBootType()
+{
+    # same code snippet in files/scripts/syncd.sh
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
+        TYPE='warm'
+        ;;
+    *SONIC_BOOT_TYPE=fastfast*)
+        TYPE='fastfast'
+        ;;
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
+        TYPE='fast'
+        ;;
+    *)
+        TYPE='cold'
+    esac
+    echo "${TYPE}"
+}
+
+function preStartAction()
+{
+    : # nothing
+    updateSyslogConf
+}
+
+function postStartAction()
+{
+    : # nothing
+}
+
+start() {
+    # Obtain boot type from kernel arguments
+    BOOT_TYPE=`getBootType`
+
+    # Obtain our platform as we will mount directories with these names in each docker
+    PLATFORM=${PLATFORM:-`$SONIC_CFGGEN -H -v DEVICE_METADATA.localhost.platform`}
+
+
+    # Parse the device specific asic conf file, if it exists
+    ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
+    if [ -f "$ASIC_CONF" ]; then
+        source $ASIC_CONF
+    fi
+    # Obtain our HWSKU as we will mount directories with these names in each docker
+    HWSKU=${HWSKU:-`$SONIC_CFGGEN -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`}
+    MOUNTPATH="/usr/share/sonic/device/$PLATFORM/$HWSKU"
+    if [ "$DEV" ]; then
+        MOUNTPATH="$MOUNTPATH/$DEV"
+    fi
+    DOCKERCHECK=`docker inspect --type container ${DOCKERNAME} 2>/dev/null`
+    if [ "$?" -eq "0" ]; then
+        DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`
+        if [ x"$DOCKERMOUNT" == x"$MOUNTPATH" ]; then
+            preStartAction
+            echo "Starting existing ${DOCKERNAME} container with HWSKU $HWSKU"
+            /usr/local/bin/container start ${DOCKERNAME}
+            postStartAction
+            exit $?
+        fi
+
+        # docker created with a different HWSKU, remove and recreate
+        echo "Removing obsolete ${DOCKERNAME} container with HWSKU $DOCKERMOUNT"
+        docker rm -f ${DOCKERNAME}
+    fi
+    echo "Creating new ${DOCKERNAME} container with HWSKU $HWSKU"
+
+    # In Multi ASIC platforms the global database config file database_global.json will exist.
+    # Parse the file and get the include path for the database_config.json files used in
+    # various namesapces. The database_config paths are relative to the DIR of SONIC_DB_GLOBAL_JSON.
+    SONIC_DB_GLOBAL_JSON="/var/run/redis/sonic-db/database_global.json"
+    if [ -f "$SONIC_DB_GLOBAL_JSON" ]; then
+        # TODO Create a separate python script with the below logic and invoke it here.
+        redis_dir_list=`/usr/bin/python -c "import sys; import os; import json; f=open(sys.argv[1]); \
+                        global_db_dir = os.path.dirname(sys.argv[1]); data=json.load(f); \
+                        print(\" \".join([os.path.normpath(global_db_dir+'/'+elem['include']).partition('sonic-db')[0]\
+                        for elem in data['INCLUDES'] if 'namespace' in elem])); f.close()" $SONIC_DB_GLOBAL_JSON`
+    fi
+
+    if [ -z "$DEV" ]; then
+        NET="host"
+
+        # For Multi-ASIC platform we have to mount the redis paths for database instances running in different
+        # namespaces, into the single instance dockers like snmp, pmon on linux host. These global dockers
+        # will need to get/set tables from databases in different namespaces.
+        # /var/run/redis0 ---> mounted as --> /var/run/redis0
+        # /var/run/redis1 ---> mounted as --> /var/run/redis1 .. etc
+        # The below logic extracts the base DIR's where database_config.json's for various namespaces exist.
+        # redis_dir_list is a string of form "/var/run/redis0/ /var/run/redis1/ /var/run/redis2/"
+        if [ -n "$redis_dir_list" ]; then
+            for redis_dir in $redis_dir_list
+            do
+                REDIS_MNT=$REDIS_MNT" -v $redis_dir:$redis_dir:rw "
+            done
+        fi
+    else
+        # This part of code is applicable for Multi-ASIC platforms. Here we mount the namespace specific
+        # redis directory into the docker running in that namespace. Below eg: is for namespace "asic1"
+        # /var/run/redis1 ---> mounted as --> /var/run/redis1
+        # redis_dir_list is a string of form "/var/run/redis0/ /var/run/redis1/ /var/run/redis2/"
+        if [ -n "$redis_dir_list" ]; then
+            id=`expr $DEV + 1`
+            redis_dir=`echo $redis_dir_list | cut -d " " -f $id`
+            REDIS_MNT=" -v $redis_dir:$redis_dir:rw "
+        fi
+        NET="container:database$DEV"
+        DB_OPT=""
+    fi
+    docker create --privileged -t -v /host/machine.conf:/etc/machine.conf -v /etc/sonic:/etc/sonic:ro -v /host/warmboot:/var/warmboot  \
+        --net=$NET \
+        -e RUNTIME_OWNER=local \
+        --uts=host \
+        --log-opt max-size=2M --log-opt max-file=5 \
+        -v /var/run/docker-syncd$DEV:/var/run/sswsyncd \
+        -v /var/run/redis$DEV:/var/run/redis:rw \
+        -v /var/run/redis-chassis:/var/run/redis-chassis:ro \
+        -v /usr/share/sonic/device/$PLATFORM/$HWSKU/$DEV:/usr/share/sonic/hwsku:ro \
+        $REDIS_MNT \
+        -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/platform:ro \
+        --tmpfs /tmp \
+        --tmpfs /var/tmp \
+        --env "NAMESPACE_ID"="$DEV" \
+        --env "NAMESPACE_PREFIX"="$NAMESPACE_PREFIX" \
+        --env "NAMESPACE_COUNT"=$NUM_ASIC \
+        --name=$DOCKERNAME docker-syncd-brcm:latest || {
+            echo "Failed to docker run" >&1
+            exit 4
+    }
+
+    preStartAction
+    /usr/local/bin/container start ${DOCKERNAME}
+    postStartAction
+}
+
+wait() {
+    /usr/local/bin/container wait $DOCKERNAME
+}
+
+stop() {
+    /usr/local/bin/container stop $DOCKERNAME
+}
+
+DOCKERNAME=syncd
+OP=$1
+DEV=$2 # namespace/device number to operate on
+NAMESPACE_PREFIX="asic"
+DOCKERNAME=$DOCKERNAME$DEV
+if [ "$DEV" ]; then
+    NET_NS="$NAMESPACE_PREFIX$DEV" #name of the network namespace
+
+    SONIC_CFGGEN="sonic-cfggen -n $NET_NS"
+    SONIC_DB_CLI="sonic-db-cli -n $NET_NS"
+ else
+    NET_NS=""
+    SONIC_CFGGEN="sonic-cfggen"
+    SONIC_DB_CLI="sonic-db-cli"
+fi
+
+# read SONiC immutable variables
+[ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
+
+case "$1" in
+    start|wait|stop)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {start namespace(optional)|wait namespace(optional)|stop namespace(optional)}"
+        exit 1
+        ;;
+esac

--- a/sonic-scripts/DUTScript/brcm-saiserver-files/usr/lib/systemd/system/saiserver.service
+++ b/sonic-scripts/DUTScript/brcm-saiserver-files/usr/lib/systemd/system/saiserver.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=saiserver service
+Requires=database.service
+After=database.service
+
+
+
+Requires=opennsl-modules.service
+After=opennsl-modules.service
+
+Requires=updategraph.service
+After=updategraph.service
+After=interfaces-config.service
+BindsTo=sonic.target
+After=sonic.target
+Before=ntp-config.service
+
+[Service]
+User=root
+Environment=sonic_asic_platform=broadcom
+ExecStartPre=/usr/local/bin/saiserver.sh start
+ExecStart=/usr/local/bin/saiserver.sh wait
+ExecStop=/usr/local/bin/saiserver.sh stop
+
+
+[Install]
+WantedBy=sonic.target

--- a/sonic-scripts/DUTScript/brcm-saiserver-files/usr/lib/systemd/system/syncd.service
+++ b/sonic-scripts/DUTScript/brcm-saiserver-files/usr/lib/systemd/system/syncd.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=syncd service
+Requires=database.service
+After=database.service
+After=swss.service
+
+
+Requires=opennsl-modules.service
+After=opennsl-modules.service
+
+Requires=updategraph.service
+After=updategraph.service
+After=interfaces-config.service
+BindsTo=sonic.target
+After=sonic.target
+Before=ntp-config.service
+
+[Service]
+User=root
+Environment=sonic_asic_platform=broadcom
+ExecStartPre=/usr/local/bin/syncd.sh start
+ExecStart=/usr/local/bin/syncd.sh wait
+ExecStop=/usr/local/bin/syncd.sh stop
+
+
+[Install]
+WantedBy=sonic.target

--- a/sonic-scripts/DUTScript/brcm-saiserver-files/usr/local/bin/saiserver.sh
+++ b/sonic-scripts/DUTScript/brcm-saiserver-files/usr/local/bin/saiserver.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+#/usr/local/bin/saiserver.sh
+. /usr/local/bin/saiserver_common.sh
+
+function startplatform() {
+
+    # platform specific tasks
+
+    # start mellanox drivers regardless of
+    # boot type
+    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
+        BOOT_TYPE=`getBootType`
+        if [[ x"$WARM_BOOT" == x"true" || x"$BOOT_TYPE" == x"fast" ]]; then
+            export FAST_BOOT=1
+        fi
+
+        if [[ x"$WARM_BOOT" != x"true" ]]; then
+            if [[ x"$(/bin/systemctl is-active pmon)" == x"active" ]]; then
+                #/bin/systemctl start pmon
+                debug "pmon is active while saiserver starting, stop it first"
+            fi
+        fi
+
+        debug "Starting Firmware update procedure"
+        /usr/bin/mst start --with_i2cdev
+        /usr/bin/mlnx-fw-upgrade.sh
+        /etc/init.d/sxdkernel start
+        debug "Firmware update procedure ended"
+    fi
+
+    if [[ x"$WARM_BOOT" != x"true" ]]; then
+        if [ x$sonic_asic_platform == x'cavium' ]; then
+            /etc/init.d/xpnet.sh start
+        fi
+    fi
+}
+
+function waitplatform() {
+    
+    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
+        debug "Starting pmon service..."
+        #/bin/systemctl start pmon
+        debug "Started pmon service"
+    fi
+}
+
+function stopplatform1() {
+
+    if [[ x$sonic_asic_platform == x"mellanox" ]] && [[ x$TYPE == x"cold" ]]; then
+        debug "Stopping pmon service ahead of saiserver..."
+        #/bin/systemctl start pmon
+        debug "Stopped pmon service"
+    fi
+
+    if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then
+        debug "${TYPE} shutdown saiserver process ..."
+        /usr/bin/docker exec -i saiserver$DEV /usr/bin/saiserver_request_shutdown --${TYPE}
+
+        # wait until saiserver quits gracefully or force saiserver to exit after 
+        # waiting for 20 seconds
+        start_in_secs=${SECONDS}
+        end_in_secs=${SECONDS}
+        timer_threshold=20
+        while docker top saiserver$DEV | grep -q /usr/bin/saiserver \
+                && [[ $((end_in_secs - start_in_secs)) -le $timer_threshold ]]; do
+            sleep 0.1
+            end_in_secs=${SECONDS}
+        done
+
+        if [[ $((end_in_secs - start_in_secs)) -gt $timer_threshold ]]; then
+            debug "saiserver process in container saiserver$DEV did not exit gracefully" 
+        fi
+
+        /usr/bin/docker exec -i saiserver$DEV /bin/sync
+        debug "Finished ${TYPE} shutdown saiserver process ..."
+    fi
+}
+
+function stopplatform2() {
+    # platform specific tasks
+
+    if [[ x"$WARM_BOOT" != x"true" ]]; then
+        if [ x$sonic_asic_platform == x'mellanox' ]; then
+            /etc/init.d/sxdkernel stop
+            /usr/bin/mst stop
+        elif [ x$sonic_asic_platform == x'cavium' ]; then
+            /etc/init.d/xpnet.sh stop
+            /etc/init.d/xpnet.sh start
+        fi
+    fi
+}
+
+OP=$1
+DEV=$2
+
+SERVICE="saiserver"
+#PEER="swss"
+DEBUGLOG="/tmp/swss-saiserver-debug$DEV.log"
+LOCKFILE="/tmp/swss-saiserver-lock$DEV"
+NAMESPACE_PREFIX="asic"
+if [ "$DEV" ]; then
+    NET_NS="$NAMESPACE_PREFIX$DEV" #name of the network namespace
+    SONIC_DB_CLI="sonic-db-cli -n $NET_NS"
+else
+    NET_NS=""
+    SONIC_DB_CLI="sonic-db-cli"
+fi
+
+case "$1" in
+    start|wait|stop)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {start|wait|stop}"
+        exit 1
+        ;;
+esac

--- a/sonic-scripts/DUTScript/brcm-saiserver-files/usr/local/bin/saiserver_common.sh
+++ b/sonic-scripts/DUTScript/brcm-saiserver-files/usr/local/bin/saiserver_common.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+#/usr/local/bin/saiserver_common.sh
+#
+# common functions used by "saiserver" scipts (saiserver.sh, gbsaiserver.sh, etc..)
+# scripts using this must provide implementations of the following functions:
+# 
+# startplatform
+# waitplatform
+# stopplatform1 and stopplatform2
+# 
+# For examples of these, see gbsaiserver.sh and saiserver.sh.
+#
+
+function debug()
+{
+    /usr/bin/logger $1
+    /bin/echo `date` "- $1" >> ${DEBUGLOG}
+}
+
+function lock_service_state_change()
+{
+    debug "Locking ${LOCKFILE} from ${SERVICE}$DEV service"
+
+    exec {LOCKFD}>${LOCKFILE}
+    /usr/bin/flock -x ${LOCKFD}
+    trap "/usr/bin/flock -u ${LOCKFD}" 0 2 3 15
+
+    debug "Locked ${LOCKFILE} (${LOCKFD}) from ${SERVICE}$DEV service"
+}
+
+function unlock_service_state_change()
+{
+    debug "Unlocking ${LOCKFILE} (${LOCKFD}) from ${SERVICE}$DEV service"
+    /usr/bin/flock -u ${LOCKFD}
+}
+
+function check_warm_boot()
+{
+    SYSTEM_WARM_START=`$SONIC_DB_CLI STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SERVICE_WARM_START=`$SONIC_DB_CLI STATE_DB hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
+    # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
+    if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
+        WARM_BOOT="true"
+    else
+        WARM_BOOT="false"
+    fi
+}
+
+function wait_for_database_service()
+{
+    # Wait for redis server start before database clean
+    until [[ $($SONIC_DB_CLI PING | grep -c PONG) -gt 0 ]]; do
+      sleep 1;
+    done
+
+    # Wait for configDB initialization
+    until [[ $($SONIC_DB_CLI CONFIG_DB GET "CONFIG_DB_INITIALIZED") ]];
+        do sleep 1;
+    done
+}
+
+function getBootType()
+{
+    # same code snippet in files/build_templates/docker_image_ctl.j2
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
+        TYPE='warm'
+        ;;
+    *SONIC_BOOT_TYPE=fastfast*)
+        TYPE='fastfast'
+        ;;
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
+        # check that the key exists
+        if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+            TYPE='fast'
+        else
+            TYPE='cold'
+        fi
+        ;;
+    *)
+        TYPE='cold'
+    esac
+    echo "${TYPE}"
+}
+
+start() {
+    debug "Starting ${SERVICE}$DEV service..."
+
+   #lock_service_state_change
+
+    mkdir -p /host/warmboot
+
+    wait_for_database_service
+    check_warm_boot
+
+    debug "Warm boot flag: ${SERVICE}$DEV ${WARM_BOOT}."
+
+    if [[ x"$WARM_BOOT" == x"true" ]]; then
+        # Leave a mark for saiserver scripts running inside docker.
+        touch /host/warmboot/warm-starting
+    else
+        rm -f /host/warmboot/warm-starting
+    fi
+
+    startplatform
+
+    # start service docker
+    /usr/bin/${SERVICE}.sh start $DEV
+    debug "Started ${SERVICE} service..."
+
+   #unlock_service_state_change
+}
+
+wait() {
+    waitplatform
+
+    /usr/bin/${SERVICE}.sh wait $DEV
+}
+
+stop() {
+    debug "Stopping ${SERVICE}$DEV service..."
+
+   #lock_service_state_change
+    check_warm_boot
+    debug "Warm boot flag: ${SERVICE}$DEV ${WARM_BOOT}."
+
+    if [[ x"$WARM_BOOT" == x"true" ]]; then
+        TYPE=warm
+    else
+        TYPE=cold
+    fi
+
+    stopplatform1
+
+    /usr/bin/${SERVICE}.sh stop $DEV
+    debug "Stopped ${SERVICE}$DEV service..."
+
+    stopplatform2
+
+   #unlock_service_state_change
+}

--- a/sonic-scripts/DUTScript/brcm-saiserver-files/usr/local/bin/syncd.sh
+++ b/sonic-scripts/DUTScript/brcm-saiserver-files/usr/local/bin/syncd.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+#/usr/local/bin/syncd.sh
+. /usr/local/bin/syncd_common.sh
+
+function startplatform() {
+
+    # platform specific tasks
+
+    # start mellanox drivers regardless of
+    # boot type
+    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
+        BOOT_TYPE=`getBootType`
+        if [[ x"$WARM_BOOT" == x"true" || x"$BOOT_TYPE" == x"fast" ]]; then
+            export FAST_BOOT=1
+        fi
+
+        if [[ x"$WARM_BOOT" != x"true" ]]; then
+            if [[ x"$(/bin/systemctl is-active pmon)" == x"active" ]]; then
+                /bin/systemctl stop pmon
+                debug "pmon is active while syncd starting, stop it first"
+            fi
+        fi
+
+        debug "Starting Firmware update procedure"
+        /usr/bin/mst start --with_i2cdev
+        /usr/bin/mlnx-fw-upgrade.sh
+        /etc/init.d/sxdkernel start
+        debug "Firmware update procedure ended"
+    fi
+
+    if [[ x"$WARM_BOOT" != x"true" ]]; then
+        if [ x$sonic_asic_platform == x'cavium' ]; then
+            /etc/init.d/xpnet.sh start
+        fi
+    fi
+}
+
+function waitplatform() {
+    
+    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
+        debug "Starting pmon service..."
+        /bin/systemctl start pmon
+        debug "Started pmon service"
+    fi
+}
+
+function stopplatform1() {
+
+    if [[ x$sonic_asic_platform == x"mellanox" ]] && [[ x$TYPE == x"cold" ]]; then
+        debug "Stopping pmon service ahead of syncd..."
+        /bin/systemctl stop pmon
+        debug "Stopped pmon service"
+    fi
+
+    if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then
+        debug "${TYPE} shutdown syncd process ..."
+        /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_shutdown --${TYPE}
+
+        # wait until syncd quits gracefully or force syncd to exit after 
+        # waiting for 20 seconds
+        start_in_secs=${SECONDS}
+        end_in_secs=${SECONDS}
+        timer_threshold=20
+        while docker top syncd$DEV | grep -q /usr/bin/syncd \
+                && [[ $((end_in_secs - start_in_secs)) -le $timer_threshold ]]; do
+            sleep 0.1
+            end_in_secs=${SECONDS}
+        done
+
+        if [[ $((end_in_secs - start_in_secs)) -gt $timer_threshold ]]; then
+            debug "syncd process in container syncd$DEV did not exit gracefully" 
+        fi
+
+        /usr/bin/docker exec -i syncd$DEV /bin/sync
+        debug "Finished ${TYPE} shutdown syncd process ..."
+    fi
+}
+
+function stopplatform2() {
+    # platform specific tasks
+
+    if [[ x"$WARM_BOOT" != x"true" ]]; then
+        if [ x$sonic_asic_platform == x'mellanox' ]; then
+            /etc/init.d/sxdkernel stop
+            /usr/bin/mst stop
+        elif [ x$sonic_asic_platform == x'cavium' ]; then
+            /etc/init.d/xpnet.sh stop
+            /etc/init.d/xpnet.sh start
+        fi
+    fi
+}
+
+OP=$1
+DEV=$2
+
+SERVICE="syncd"
+PEER="swss"
+DEBUGLOG="/tmp/swss-syncd-debug$DEV.log"
+LOCKFILE="/tmp/swss-syncd-lock$DEV"
+NAMESPACE_PREFIX="asic"
+if [ "$DEV" ]; then
+    NET_NS="$NAMESPACE_PREFIX$DEV" #name of the network namespace
+    SONIC_DB_CLI="sonic-db-cli -n $NET_NS"
+else
+    NET_NS=""
+    SONIC_DB_CLI="sonic-db-cli"
+fi
+
+case "$1" in
+    start|wait|stop)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {start|wait|stop}"
+        exit 1
+        ;;
+esac

--- a/sonic-scripts/DUTScript/brcm-saiserver-files/usr/local/bin/syncd_common.sh
+++ b/sonic-scripts/DUTScript/brcm-saiserver-files/usr/local/bin/syncd_common.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+#/usr/local/bin/syncd_common.sh
+#
+# common functions used by "syncd" scipts (syncd.sh, gbsyncd.sh, etc..)
+# scripts using this must provide implementations of the following functions:
+# 
+# startplatform
+# waitplatform
+# stopplatform1 and stopplatform2
+# 
+# For examples of these, see gbsyncd.sh and syncd.sh.
+#
+
+function debug()
+{
+    /usr/bin/logger $1
+    /bin/echo `date` "- $1" >> ${DEBUGLOG}
+}
+
+function lock_service_state_change()
+{
+    debug "Locking ${LOCKFILE} from ${SERVICE}$DEV service"
+
+    exec {LOCKFD}>${LOCKFILE}
+    /usr/bin/flock -x ${LOCKFD}
+    trap "/usr/bin/flock -u ${LOCKFD}" 0 2 3 15
+
+    debug "Locked ${LOCKFILE} (${LOCKFD}) from ${SERVICE}$DEV service"
+}
+
+function unlock_service_state_change()
+{
+    debug "Unlocking ${LOCKFILE} (${LOCKFD}) from ${SERVICE}$DEV service"
+    /usr/bin/flock -u ${LOCKFD}
+}
+
+function check_warm_boot()
+{
+    SYSTEM_WARM_START=`$SONIC_DB_CLI STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SERVICE_WARM_START=`$SONIC_DB_CLI STATE_DB hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
+    # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
+    if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
+        WARM_BOOT="true"
+    else
+        WARM_BOOT="false"
+    fi
+}
+
+function wait_for_database_service()
+{
+    # Wait for redis server start before database clean
+    until [[ $($SONIC_DB_CLI PING | grep -c PONG) -gt 0 ]]; do
+      sleep 1;
+    done
+
+    # Wait for configDB initialization
+    until [[ $($SONIC_DB_CLI CONFIG_DB GET "CONFIG_DB_INITIALIZED") ]];
+        do sleep 1;
+    done
+}
+
+function getBootType()
+{
+    # same code snippet in files/build_templates/docker_image_ctl.j2
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
+        TYPE='warm'
+        ;;
+    *SONIC_BOOT_TYPE=fastfast*)
+        TYPE='fastfast'
+        ;;
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
+        # check that the key exists
+        if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+            TYPE='fast'
+        else
+            TYPE='cold'
+        fi
+        ;;
+    *)
+        TYPE='cold'
+    esac
+    echo "${TYPE}"
+}
+
+start() {
+    debug "Starting ${SERVICE}$DEV service..."
+
+    lock_service_state_change
+
+    mkdir -p /host/warmboot
+
+    wait_for_database_service
+    check_warm_boot
+
+    debug "Warm boot flag: ${SERVICE}$DEV ${WARM_BOOT}."
+
+    if [[ x"$WARM_BOOT" == x"true" ]]; then
+        # Leave a mark for syncd scripts running inside docker.
+        touch /host/warmboot/warm-starting
+    else
+        rm -f /host/warmboot/warm-starting
+    fi
+
+    startplatform
+
+    # start service docker
+    /usr/bin/${SERVICE}.sh start $DEV
+    debug "Started ${SERVICE} service..."
+
+    unlock_service_state_change
+}
+
+wait() {
+    waitplatform
+
+    /usr/bin/${SERVICE}.sh wait $DEV
+}
+
+stop() {
+    debug "Stopping ${SERVICE}$DEV service..."
+
+    lock_service_state_change
+    check_warm_boot
+    debug "Warm boot flag: ${SERVICE}$DEV ${WARM_BOOT}."
+
+    if [[ x"$WARM_BOOT" == x"true" ]]; then
+        TYPE=warm
+    else
+        TYPE=cold
+    fi
+
+    stopplatform1
+
+    /usr/bin/${SERVICE}.sh stop $DEV
+    debug "Stopped ${SERVICE}$DEV service..."
+
+    stopplatform2
+
+    unlock_service_state_change
+}

--- a/sonic-scripts/DUTScript/brcm-syncd-files/usr/bin/syncd.sh
+++ b/sonic-scripts/DUTScript/brcm-syncd-files/usr/bin/syncd.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+
+#/usr/bin/syncd.sh
+# single instance containers are still supported (even though it might not look like it)
+# if no instance number is passed to this script, $DEV will simply be unset, resulting in docker
+# commands being sent to the base container name. E.g. `docker start database$DEV` simply starts
+# the container `database` if no instance number is passed since `$DEV` is not defined
+
+function updateSyslogConf()
+{
+    # On multiNPU platforms, change the syslog target ip to docker0 ip to allow logs from containers
+    # running on the namespace to reach the rsyslog service running on the host
+    # Also update the container name  
+    if [[ ($NUM_ASIC -gt 1) ]]; then
+        TARGET_IP=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')
+        CONTAINER_NAME="$DOCKERNAME"
+        TMP_FILE="/tmp/rsyslog.$CONTAINER_NAME.conf"
+
+        sonic-cfggen -t /usr/share/sonic/templates/rsyslog-container.conf.j2 -a "{\"target_ip\": \"$TARGET_IP\", \"container_name\": \"$CONTAINER_NAME\" }"  > $TMP_FILE
+        docker cp $TMP_FILE ${DOCKERNAME}:/etc/rsyslog.conf
+        rm -rf $TMP_FILE
+    fi
+}
+
+function getMountPoint()
+{
+    echo $1 | python -c "import sys, json, os; mnts = [x for x in json.load(sys.stdin)[0]['Mounts'] if x['Destination'] == '/usr/share/sonic/hwsku']; print '' if len(mnts) == 0 else os.path.abspath(mnts[0]['Source'])" 2>/dev/null
+}
+
+function getBootType()
+{
+    # same code snippet in files/scripts/syncd.sh
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
+        TYPE='warm'
+        ;;
+    *SONIC_BOOT_TYPE=fastfast*)
+        TYPE='fastfast'
+        ;;
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
+        TYPE='fast'
+        ;;
+    *)
+        TYPE='cold'
+    esac
+    echo "${TYPE}"
+}
+
+function preStartAction()
+{
+    : # nothing
+    updateSyslogConf
+}
+
+function postStartAction()
+{
+    : # nothing
+}
+
+start() {
+    # Obtain boot type from kernel arguments
+    BOOT_TYPE=`getBootType`
+
+    # Obtain our platform as we will mount directories with these names in each docker
+    PLATFORM=${PLATFORM:-`$SONIC_CFGGEN -H -v DEVICE_METADATA.localhost.platform`}
+
+
+    # Parse the device specific asic conf file, if it exists
+    ASIC_CONF=/usr/share/sonic/device/$PLATFORM/asic.conf
+    if [ -f "$ASIC_CONF" ]; then
+        source $ASIC_CONF
+    fi
+    # Obtain our HWSKU as we will mount directories with these names in each docker
+    HWSKU=${HWSKU:-`$SONIC_CFGGEN -d -v 'DEVICE_METADATA["localhost"]["hwsku"]'`}
+    MOUNTPATH="/usr/share/sonic/device/$PLATFORM/$HWSKU"
+    if [ "$DEV" ]; then
+        MOUNTPATH="$MOUNTPATH/$DEV"
+    fi
+    DOCKERCHECK=`docker inspect --type container ${DOCKERNAME} 2>/dev/null`
+    if [ "$?" -eq "0" ]; then
+        DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`
+        if [ x"$DOCKERMOUNT" == x"$MOUNTPATH" ]; then
+            preStartAction
+            echo "Starting existing ${DOCKERNAME} container with HWSKU $HWSKU"
+            /usr/local/bin/container start ${DOCKERNAME}
+            postStartAction
+            exit $?
+        fi
+
+        # docker created with a different HWSKU, remove and recreate
+        echo "Removing obsolete ${DOCKERNAME} container with HWSKU $DOCKERMOUNT"
+        docker rm -f ${DOCKERNAME}
+    fi
+    echo "Creating new ${DOCKERNAME} container with HWSKU $HWSKU"
+
+    # In Multi ASIC platforms the global database config file database_global.json will exist.
+    # Parse the file and get the include path for the database_config.json files used in
+    # various namesapces. The database_config paths are relative to the DIR of SONIC_DB_GLOBAL_JSON.
+    SONIC_DB_GLOBAL_JSON="/var/run/redis/sonic-db/database_global.json"
+    if [ -f "$SONIC_DB_GLOBAL_JSON" ]; then
+        # TODO Create a separate python script with the below logic and invoke it here.
+        redis_dir_list=`/usr/bin/python -c "import sys; import os; import json; f=open(sys.argv[1]); \
+                        global_db_dir = os.path.dirname(sys.argv[1]); data=json.load(f); \
+                        print(\" \".join([os.path.normpath(global_db_dir+'/'+elem['include']).partition('sonic-db')[0]\
+                        for elem in data['INCLUDES'] if 'namespace' in elem])); f.close()" $SONIC_DB_GLOBAL_JSON`
+    fi
+
+    if [ -z "$DEV" ]; then
+        NET="host"
+
+        # For Multi-ASIC platform we have to mount the redis paths for database instances running in different
+        # namespaces, into the single instance dockers like snmp, pmon on linux host. These global dockers
+        # will need to get/set tables from databases in different namespaces.
+        # /var/run/redis0 ---> mounted as --> /var/run/redis0
+        # /var/run/redis1 ---> mounted as --> /var/run/redis1 .. etc
+        # The below logic extracts the base DIR's where database_config.json's for various namespaces exist.
+        # redis_dir_list is a string of form "/var/run/redis0/ /var/run/redis1/ /var/run/redis2/"
+        if [ -n "$redis_dir_list" ]; then
+            for redis_dir in $redis_dir_list
+            do
+                REDIS_MNT=$REDIS_MNT" -v $redis_dir:$redis_dir:rw "
+            done
+        fi
+    else
+        # This part of code is applicable for Multi-ASIC platforms. Here we mount the namespace specific
+        # redis directory into the docker running in that namespace. Below eg: is for namespace "asic1"
+        # /var/run/redis1 ---> mounted as --> /var/run/redis1
+        # redis_dir_list is a string of form "/var/run/redis0/ /var/run/redis1/ /var/run/redis2/"
+        if [ -n "$redis_dir_list" ]; then
+            id=`expr $DEV + 1`
+            redis_dir=`echo $redis_dir_list | cut -d " " -f $id`
+            REDIS_MNT=" -v $redis_dir:$redis_dir:rw "
+        fi
+        NET="container:database$DEV"
+        DB_OPT=""
+    fi
+    docker create --privileged -t -v /host/machine.conf:/etc/machine.conf -v /etc/sonic:/etc/sonic:ro -v /host/warmboot:/var/warmboot  \
+        --net=$NET \
+        -e RUNTIME_OWNER=local \
+        --uts=host \
+        --log-opt max-size=2M --log-opt max-file=5 \
+        -v /var/run/docker-syncd$DEV:/var/run/sswsyncd \
+        -v /var/run/redis$DEV:/var/run/redis:rw \
+        -v /var/run/redis-chassis:/var/run/redis-chassis:ro \
+        -v /usr/share/sonic/device/$PLATFORM/$HWSKU/$DEV:/usr/share/sonic/hwsku:ro \
+        $REDIS_MNT \
+        -v /usr/share/sonic/device/$PLATFORM:/usr/share/sonic/platform:ro \
+        --tmpfs /tmp \
+        --tmpfs /var/tmp \
+        --env "NAMESPACE_ID"="$DEV" \
+        --env "NAMESPACE_PREFIX"="$NAMESPACE_PREFIX" \
+        --env "NAMESPACE_COUNT"=$NUM_ASIC \
+        --name=$DOCKERNAME docker-syncd-brcm:latest || {
+            echo "Failed to docker run" >&1
+            exit 4
+    }
+
+    preStartAction
+    /usr/local/bin/container start ${DOCKERNAME}
+    postStartAction
+}
+
+wait() {
+    /usr/local/bin/container wait $DOCKERNAME
+}
+
+stop() {
+    /usr/local/bin/container stop $DOCKERNAME
+}
+
+DOCKERNAME=syncd
+OP=$1
+DEV=$2 # namespace/device number to operate on
+NAMESPACE_PREFIX="asic"
+DOCKERNAME=$DOCKERNAME$DEV
+if [ "$DEV" ]; then
+    NET_NS="$NAMESPACE_PREFIX$DEV" #name of the network namespace
+
+    SONIC_CFGGEN="sonic-cfggen -n $NET_NS"
+    SONIC_DB_CLI="sonic-db-cli -n $NET_NS"
+ else
+    NET_NS=""
+    SONIC_CFGGEN="sonic-cfggen"
+    SONIC_DB_CLI="sonic-db-cli"
+fi
+
+# read SONiC immutable variables
+[ -f /etc/sonic/sonic-environment ] && . /etc/sonic/sonic-environment
+
+case "$1" in
+    start|wait|stop)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {start namespace(optional)|wait namespace(optional)|stop namespace(optional)}"
+        exit 1
+        ;;
+esac

--- a/sonic-scripts/DUTScript/brcm-syncd-files/usr/lib/systemd/system/syncd.service
+++ b/sonic-scripts/DUTScript/brcm-syncd-files/usr/lib/systemd/system/syncd.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=syncd service
+Requires=database.service
+After=database.service
+After=swss.service
+
+
+Requires=opennsl-modules.service
+After=opennsl-modules.service
+
+Requires=updategraph.service
+After=updategraph.service
+After=interfaces-config.service
+BindsTo=sonic.target
+After=sonic.target
+Before=ntp-config.service
+
+[Service]
+User=root
+Environment=sonic_asic_platform=broadcom
+ExecStartPre=/usr/local/bin/syncd.sh start
+ExecStart=/usr/local/bin/syncd.sh wait
+ExecStop=/usr/local/bin/syncd.sh stop
+
+
+[Install]
+WantedBy=sonic.target

--- a/sonic-scripts/DUTScript/brcm-syncd-files/usr/local/bin/syncd.sh
+++ b/sonic-scripts/DUTScript/brcm-syncd-files/usr/local/bin/syncd.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+#/usr/local/bin/syncd.sh
+. /usr/local/bin/syncd_common.sh
+
+function startplatform() {
+
+    # platform specific tasks
+
+    # start mellanox drivers regardless of
+    # boot type
+    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
+        BOOT_TYPE=`getBootType`
+        if [[ x"$WARM_BOOT" == x"true" || x"$BOOT_TYPE" == x"fast" ]]; then
+            export FAST_BOOT=1
+        fi
+
+        if [[ x"$WARM_BOOT" != x"true" ]]; then
+            if [[ x"$(/bin/systemctl is-active pmon)" == x"active" ]]; then
+                /bin/systemctl stop pmon
+                debug "pmon is active while syncd starting, stop it first"
+            fi
+        fi
+
+        debug "Starting Firmware update procedure"
+        /usr/bin/mst start --with_i2cdev
+        /usr/bin/mlnx-fw-upgrade.sh
+        /etc/init.d/sxdkernel start
+        debug "Firmware update procedure ended"
+    fi
+
+    if [[ x"$WARM_BOOT" != x"true" ]]; then
+        if [ x$sonic_asic_platform == x'cavium' ]; then
+            /etc/init.d/xpnet.sh start
+        fi
+    fi
+}
+
+function waitplatform() {
+    
+    if [[ x"$sonic_asic_platform" == x"mellanox" ]]; then
+        debug "Starting pmon service..."
+        /bin/systemctl start pmon
+        debug "Started pmon service"
+    fi
+}
+
+function stopplatform1() {
+
+    if [[ x$sonic_asic_platform == x"mellanox" ]] && [[ x$TYPE == x"cold" ]]; then
+        debug "Stopping pmon service ahead of syncd..."
+        /bin/systemctl stop pmon
+        debug "Stopped pmon service"
+    fi
+
+    if [[ x$sonic_asic_platform != x"mellanox" ]] || [[ x$TYPE != x"cold" ]]; then
+        debug "${TYPE} shutdown syncd process ..."
+        /usr/bin/docker exec -i syncd$DEV /usr/bin/syncd_request_shutdown --${TYPE}
+
+        # wait until syncd quits gracefully or force syncd to exit after 
+        # waiting for 20 seconds
+        start_in_secs=${SECONDS}
+        end_in_secs=${SECONDS}
+        timer_threshold=20
+        while docker top syncd$DEV | grep -q /usr/bin/syncd \
+                && [[ $((end_in_secs - start_in_secs)) -le $timer_threshold ]]; do
+            sleep 0.1
+            end_in_secs=${SECONDS}
+        done
+
+        if [[ $((end_in_secs - start_in_secs)) -gt $timer_threshold ]]; then
+            debug "syncd process in container syncd$DEV did not exit gracefully" 
+        fi
+
+        /usr/bin/docker exec -i syncd$DEV /bin/sync
+        debug "Finished ${TYPE} shutdown syncd process ..."
+    fi
+}
+
+function stopplatform2() {
+    # platform specific tasks
+
+    if [[ x"$WARM_BOOT" != x"true" ]]; then
+        if [ x$sonic_asic_platform == x'mellanox' ]; then
+            /etc/init.d/sxdkernel stop
+            /usr/bin/mst stop
+        elif [ x$sonic_asic_platform == x'cavium' ]; then
+            /etc/init.d/xpnet.sh stop
+            /etc/init.d/xpnet.sh start
+        fi
+    fi
+}
+
+OP=$1
+DEV=$2
+
+SERVICE="syncd"
+PEER="swss"
+DEBUGLOG="/tmp/swss-syncd-debug$DEV.log"
+LOCKFILE="/tmp/swss-syncd-lock$DEV"
+NAMESPACE_PREFIX="asic"
+if [ "$DEV" ]; then
+    NET_NS="$NAMESPACE_PREFIX$DEV" #name of the network namespace
+    SONIC_DB_CLI="sonic-db-cli -n $NET_NS"
+else
+    NET_NS=""
+    SONIC_DB_CLI="sonic-db-cli"
+fi
+
+case "$1" in
+    start|wait|stop)
+        $1
+        ;;
+    *)
+        echo "Usage: $0 {start|wait|stop}"
+        exit 1
+        ;;
+esac

--- a/sonic-scripts/DUTScript/brcm-syncd-files/usr/local/bin/syncd_common.sh
+++ b/sonic-scripts/DUTScript/brcm-syncd-files/usr/local/bin/syncd_common.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+#/usr/local/bin/syncd_common.sh
+#
+# common functions used by "syncd" scipts (syncd.sh, gbsyncd.sh, etc..)
+# scripts using this must provide implementations of the following functions:
+# 
+# startplatform
+# waitplatform
+# stopplatform1 and stopplatform2
+# 
+# For examples of these, see gbsyncd.sh and syncd.sh.
+#
+
+function debug()
+{
+    /usr/bin/logger $1
+    /bin/echo `date` "- $1" >> ${DEBUGLOG}
+}
+
+function lock_service_state_change()
+{
+    debug "Locking ${LOCKFILE} from ${SERVICE}$DEV service"
+
+    exec {LOCKFD}>${LOCKFILE}
+    /usr/bin/flock -x ${LOCKFD}
+    trap "/usr/bin/flock -u ${LOCKFD}" 0 2 3 15
+
+    debug "Locked ${LOCKFILE} (${LOCKFD}) from ${SERVICE}$DEV service"
+}
+
+function unlock_service_state_change()
+{
+    debug "Unlocking ${LOCKFILE} (${LOCKFD}) from ${SERVICE}$DEV service"
+    /usr/bin/flock -u ${LOCKFD}
+}
+
+function check_warm_boot()
+{
+    SYSTEM_WARM_START=`$SONIC_DB_CLI STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
+    SERVICE_WARM_START=`$SONIC_DB_CLI STATE_DB hget "WARM_RESTART_ENABLE_TABLE|${SERVICE}" enable`
+    # SYSTEM_WARM_START could be empty, always make WARM_BOOT meaningful.
+    if [[ x"$SYSTEM_WARM_START" == x"true" ]] || [[ x"$SERVICE_WARM_START" == x"true" ]]; then
+        WARM_BOOT="true"
+    else
+        WARM_BOOT="false"
+    fi
+}
+
+function wait_for_database_service()
+{
+    # Wait for redis server start before database clean
+    until [[ $($SONIC_DB_CLI PING | grep -c PONG) -gt 0 ]]; do
+      sleep 1;
+    done
+
+    # Wait for configDB initialization
+    until [[ $($SONIC_DB_CLI CONFIG_DB GET "CONFIG_DB_INITIALIZED") ]];
+        do sleep 1;
+    done
+}
+
+function getBootType()
+{
+    # same code snippet in files/build_templates/docker_image_ctl.j2
+    case "$(cat /proc/cmdline)" in
+    *SONIC_BOOT_TYPE=warm*)
+        TYPE='warm'
+        ;;
+    *SONIC_BOOT_TYPE=fastfast*)
+        TYPE='fastfast'
+        ;;
+    *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
+        # check that the key exists
+        if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+            TYPE='fast'
+        else
+            TYPE='cold'
+        fi
+        ;;
+    *)
+        TYPE='cold'
+    esac
+    echo "${TYPE}"
+}
+
+start() {
+    debug "Starting ${SERVICE}$DEV service..."
+
+    lock_service_state_change
+
+    mkdir -p /host/warmboot
+
+    wait_for_database_service
+    check_warm_boot
+
+    debug "Warm boot flag: ${SERVICE}$DEV ${WARM_BOOT}."
+
+    if [[ x"$WARM_BOOT" == x"true" ]]; then
+        # Leave a mark for syncd scripts running inside docker.
+        touch /host/warmboot/warm-starting
+    else
+        rm -f /host/warmboot/warm-starting
+    fi
+
+    startplatform
+
+    # start service docker
+    /usr/bin/${SERVICE}.sh start $DEV
+    debug "Started ${SERVICE} service..."
+
+    unlock_service_state_change
+}
+
+wait() {
+    waitplatform
+
+    /usr/bin/${SERVICE}.sh wait $DEV
+}
+
+stop() {
+    debug "Stopping ${SERVICE}$DEV service..."
+
+    lock_service_state_change
+    check_warm_boot
+    debug "Warm boot flag: ${SERVICE}$DEV ${WARM_BOOT}."
+
+    if [[ x"$WARM_BOOT" == x"true" ]]; then
+        TYPE=warm
+    else
+        TYPE=cold
+    fi
+
+    stopplatform1
+
+    /usr/bin/${SERVICE}.sh stop $DEV
+    debug "Stopped ${SERVICE}$DEV service..."
+
+    stopplatform2
+
+    unlock_service_state_change
+}


### PR DESCRIPTION
for script sonic-scripts/DUTScript/prepare_saiserver_service.sh, it can help prepare a saiserver start script, which modified from syncd start script in DUT (base on actual device data).

by setting those parameters in sonic-scripts/DUTScript/prepare_saiserver_service.sh, we can use those sample data and make some basic test
```
SYNCD_SCRIPT_ROOT=""
SAISERVER_SCRIPT_ROOT=""
SAISERVER_COMMON=$SAISERVER_SCRIPT_ROOT/usr/local/bin/saiserver_common.sh
SAISERVER_LOCAL=$SAISERVER_SCRIPT_ROOT/usr/local/bin/saiserver.sh
SAISERVER_SERVICE=$SAISERVER_SCRIPT_ROOT/usr/lib/systemd/system/saiserver.service
SAISERVER=$SAISERVER_SCRIPT_ROOT/usr/bin/saiserver.sh
```